### PR TITLE
[bug]Google Analytics does not work

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,7 +19,7 @@
         {{- partial "head/seo.html" . -}}
 
         {{- $analytics := .Site.Config.Privacy.GoogleAnalytics -}}
-        {{- if not $analytics.Disable }}{{ with .Site.GoogleAnalytics -}}
+        {{- if not $analytics.Disable }}{{ if .Site.GoogleAnalytics -}}
             {{ template "_internal/google_analytics.html" . }}
         {{- end -}}{{ end -}}
     </head>


### PR DESCRIPTION
When enabled google analytics in config.toml , `can't evaluate field Site in type string` errors occured.

To avoid rebind do not use "with."
* #61 

