### PR TITLE
Fix taxonomies

### DIFF
--- a/exampleSite/content/posts/theme-documentation-basics/index.en.md
+++ b/exampleSite/content/posts/theme-documentation-basics/index.en.md
@@ -90,6 +90,10 @@ theme = "FeelIt"
 [params]
   # FeelIt theme version
   version = "1.0.X"
+  
+[taxonomies]
+  tag = "tags"
+  category = "categories"
 
 [menu]
   [[menu.main]]


### PR DESCRIPTION
Showing only 'tags' taxonomy is fixed. Now list pages for both tags and categories will be generated