### PR TITLE
Correct icon for StackOverflow

### DIFF
--- a/assets/data/social.yml
+++ b/assets/data/social.yml
@@ -156,7 +156,7 @@ stackoverflow:
   Prefix: https://stackoverflow.com/users/
   Title: Stack Overflow
   Icon:
-    Class: fab fa-codepen fa-fw
+    Class: fab fa-stack-overflow fa-fw
 
 # 021: 微博
 weibo:


### PR DESCRIPTION
Fixed the icon for StackOverflow (it was using the one for Codepen).