### PR TITLE
Improve image path handling

### DIFF
--- a/layouts/_partials/plugin/image.html
+++ b/layouts/_partials/plugin/image.html
@@ -1,18 +1,22 @@
 {{- /* lazysizes and lightgallery.js */ -}}
-{{- $src := .Src -}}
-{{- with dict "Path" .Src "Resources" .Resources | partial "function/resource.html" -}}
-    {{- $src = .RelPermalink -}}
+{{- $scratch := newScratch -}}
+{{- range $key, $path := dict "src" .Src "small" .SrcSmall "large" .SrcLarge -}}
+    {{- if $path -}}
+        {{- $url := $path -}}
+        {{- with dict "Path" $path "Resources" $.Resources | partial "function/resource.html" -}}
+            {{- $url = .Permalink -}}
+        {{- else -}}
+            {{- if not (urls.Parse $path).IsAbs -}}
+                {{- $url = $path | relURL -}}
+            {{- end -}}
+        {{- end -}}
+        {{- $scratch.Set $key $url -}}
+    {{- end -}}
 {{- end -}}
 
-{{- $small := .SrcSmall | default $src -}}
-{{- with dict "Path" .SrcSmall "Resources" .Resources | partial "function/resource.html" -}}
-    {{- $small = .RelPermalink -}}
-{{- end -}}
-
-{{- $large := .SrcLarge | default $src -}}
-{{- with dict "Path" .SrcLarge "Resources" .Resources | partial "function/resource.html" -}}
-    {{- $large = .RelPermalink -}}
-{{- end -}}
+{{- $src := $scratch.Get "src" -}}
+{{- $small := $scratch.Get "small" | default $src -}}
+{{- $large := $scratch.Get "large" | default $src -}}
 
 {{- $alt := .Alt | default $src -}}
 {{- $loading := resources.Get "svg/loading.svg" | minify -}}
@@ -21,8 +25,8 @@
         <img
             class="lazyload{{ with .Class }} {{ . }}{{ end }}"
             src="{{ $loading.RelPermalink }}"
-            data-src="{{ .Src | safeURL }}"
-            data-srcset="{{ $small | safeURL }}, {{ .Src | safeURL }} 1.5x, {{ $large | safeURL }} 2x"
+            data-src="{{ $src | safeURL }}"
+            data-srcset="{{ $small | safeURL }}, {{ $src | safeURL }} 1.5x, {{ $large | safeURL }} 2x"
             data-sizes="auto"
             alt="{{ $alt }}"{{ with .Height }} height="{{ . }}"{{ end }}{{ with .Width }} width="{{ . }}"{{ end }} />
     </a>
@@ -30,8 +34,8 @@
     <img
         class="lazyload{{ with .Class }} {{ . }}{{ end }}"
         src="{{ $loading.RelPermalink }}"
-        data-src="{{ .Src | safeURL }}"
-        data-srcset="{{ $small | safeURL }}, {{ .Src | safeURL }} 1.5x, {{ $large | safeURL }} 2x"
+        data-src="{{ $src | safeURL }}"
+        data-srcset="{{ $small | safeURL }}, {{ $src | safeURL }} 1.5x, {{ $large | safeURL }} 2x"
         data-sizes="auto"
         alt="{{ $alt }}"
         title="{{ .Title | default $alt }}"{{ with .Height }} height="{{ . }}"{{ end }}{{ with .Width }} width="{{ . }}"{{ end }} />


### PR DESCRIPTION
In layouts/_partials/plugin/image.html, after the resource lookup fails, check if .Src is a relative path (doesn't start with / and has no host) and prepend / to make it absolute:

```
  {{- $src := .Src -}}
  {{- with dict "Path" .Src "Resources" .Resources | partial "function/resource.html" -}}
      {{- $src = .RelPermalink -}}
  {{- else -}}
      {{- $url := urls.Parse .Src -}}
      {{- if not $url.Host -}}
          {{- if not (hasPrefix .Src "/") -}}
              {{- $src = printf "/%s" .Src -}}
          {{- end -}}
      {{- end -}}
  {{- end -}}
```

  This fix ensures that:
  1. Resource paths remain unchanged (already handled correctly)
  2. External URLs remain unchanged (checked via $url.Host)
  3. Absolute paths remain unchanged (checked via hasPrefix)
  4. Relative paths are converted to absolute paths